### PR TITLE
Skip non-application classes in reachability

### DIFF
--- a/src/main/java/org/example/LocTool.java
+++ b/src/main/java/org/example/LocTool.java
@@ -157,10 +157,17 @@ public class LocTool {
 
             while (!worklist.isEmpty()) {
                 SootMethod method = worklist.poll();
+                if (!method.getDeclaringClass().isApplicationClass()) {
+                    continue;
+                }
                 if (methods.add(method)) {
                     Iterator<Edge> edges = cg.edgesOutOf(method);
                     while (edges.hasNext()) {
-                        worklist.add(edges.next().tgt());
+                        SootMethod tgt = edges.next().tgt();
+                        if (!tgt.getDeclaringClass().isApplicationClass()) {
+                            continue;
+                        }
+                        worklist.add(tgt);
                     }
                 }
             }

--- a/src/main/java/org/example/SootAnalyzer.java
+++ b/src/main/java/org/example/SootAnalyzer.java
@@ -59,10 +59,16 @@ public class SootAnalyzer implements AutoCloseable {
 
         while (!work.isEmpty()) {
             SootMethod m = work.pop();
+            if (!m.getDeclaringClass().isApplicationClass()) {
+                continue;
+            }
             try {
                 Iterator<Edge> edges = cg.edgesOutOf(m);
                 while (edges.hasNext()) {
                     SootMethod tgt = edges.next().tgt();
+                    if (!tgt.getDeclaringClass().isApplicationClass()) {
+                        continue;
+                    }
                     if (result.add(tgt)) {
                         work.push(tgt);
                     }


### PR DESCRIPTION
## Summary
- ensure only application classes are included when collecting reachable methods
- ignore non-application classes in LocTool and SootAnalyzer

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685040706ef88321b26e7a0fd8d2d17a