### PR TITLE
Fix CLI argument parsing by mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ Soot(https://soot-oss.github.io/soot/) を用いて Java アプリケーショ�
 ## 🧩 モード仕様
 
 ```bash
-java -jar loc-tool.jar <mode> <target-jar> [entrypoints.json] [dependencies...]
+# annotation モード
+java -jar loc-tool.jar annotation <target-jar> [dependencies...]
+
+# external / hybrid モード
+java -jar loc-tool.jar <mode> <target-jar> <entrypoints.json> [dependencies...]
 ```
 
 | パラメータ | 説明 |
 |------------|------|
 | `mode` | 実行モード（annotation/external/hybrid） |
 | `target-jar` | 分析対象のjarファイル |
-| `entrypoints.json` | 外部エントリーポイントモードで使用するJSONファイル（オプション） |
+| `entrypoints.json` | external/hybrid モードで使用するJSONファイル |
 | `dependencies...` | 分析対象のjarファイルの依存関係（オプション） |
 
 | モード       | 説明 |

--- a/src/main/java/org/example/LocTool.java
+++ b/src/main/java/org/example/LocTool.java
@@ -15,17 +15,37 @@ public class LocTool {
     @Function("機能単位LOC計測")
     public static void main(String[] args) {
         if (args.length < 2) {
-            System.err.println("使用方法: java -jar loc-tool.jar <mode> <target-jar> [entrypoints.json] [dependencies...]");
+            System.err.println("使用方法:\n" +
+                    "  annotation: java -jar loc-tool.jar annotation <target-jar> [dependencies...]\n" +
+                    "  external/hybrid: java -jar loc-tool.jar <mode> <target-jar> <entrypoints.json> [dependencies...]");
             System.exit(1);
         }
 
         String mode = args[0];
         String targetJar = args[1];
-        String jsonPath = args.length > 2 ? args[2] : null;
-        
-        // 依存関係のjarファイルを取得
-        String[] dependencies = args.length > 3 ? 
-            Arrays.copyOfRange(args, 3, args.length) : new String[0];
+        String jsonPath = null;
+        String[] dependencies;
+
+        switch (mode) {
+            case "annotation" -> {
+                // annotation モード: <mode> <target-jar> [dependencies...]
+                dependencies = args.length > 2 ? Arrays.copyOfRange(args, 2, args.length) : new String[0];
+            }
+            case "external", "hybrid" -> {
+                // external / hybrid モード: <mode> <target-jar> <entrypoints.json> [dependencies...]
+                if (args.length < 3) {
+                    System.err.println("外部/ハイブリッドモードでは entrypoints.json が必要です");
+                    System.exit(1);
+                }
+                jsonPath = args[2];
+                dependencies = args.length > 3 ? Arrays.copyOfRange(args, 3, args.length) : new String[0];
+            }
+            default -> {
+                System.err.println("不明なモード: " + mode);
+                System.exit(1);
+                return; // not reached
+            }
+        }
 
         try {
             setupSoot(targetJar, dependencies);


### PR DESCRIPTION
## Summary
- support argument patterns depending on mode
- document updated CLI usage

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6850409f88fc83218bb92933b68c8135