### PR TITLE
Add descriptor parser and update entry points

### DIFF
--- a/src/main/java/org/example/DescriptorUtils.java
+++ b/src/main/java/org/example/DescriptorUtils.java
@@ -1,0 +1,77 @@
+package org.example;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import soot.ArrayType;
+import soot.BooleanType;
+import soot.ByteType;
+import soot.CharType;
+import soot.DoubleType;
+import soot.FloatType;
+import soot.IntType;
+import soot.LongType;
+import soot.RefType;
+import soot.ShortType;
+import soot.Type;
+
+/**
+ * JVMメソッド記述子を解析してSootのパラメータ型リストを生成するユーティリティ。
+ */
+public class DescriptorUtils {
+    /**
+     * メソッド記述子からパラメータ型リストを取得する。
+     *
+     * @param descriptor JVMメソッド記述子
+     * @return パラメータ型のリスト
+     */
+    public static List<Type> parseParameterTypes(String descriptor) {
+        if (descriptor == null || descriptor.isEmpty()) {
+            return Collections.emptyList();
+        }
+        int start = descriptor.indexOf('(');
+        int end = descriptor.indexOf(')');
+        if (start == -1 || end == -1 || end <= start) {
+            throw new IllegalArgumentException("Invalid descriptor: " + descriptor);
+        }
+        String params = descriptor.substring(start + 1, end);
+        List<Type> types = new ArrayList<>();
+        for (int i = 0; i < params.length();) {
+            int arrayDim = 0;
+            char c = params.charAt(i);
+            while (c == '[') {
+                arrayDim++;
+                i++;
+                c = params.charAt(i);
+            }
+            Type baseType;
+            switch (c) {
+                case 'B' -> baseType = ByteType.v();
+                case 'C' -> baseType = CharType.v();
+                case 'D' -> baseType = DoubleType.v();
+                case 'F' -> baseType = FloatType.v();
+                case 'I' -> baseType = IntType.v();
+                case 'J' -> baseType = LongType.v();
+                case 'S' -> baseType = ShortType.v();
+                case 'Z' -> baseType = BooleanType.v();
+                case 'L' -> {
+                    int semi = params.indexOf(';', i);
+                    if (semi == -1) {
+                        throw new IllegalArgumentException("Invalid descriptor: " + descriptor);
+                    }
+                    String cls = params.substring(i + 1, semi).replace('/', '.');
+                    baseType = RefType.v(cls);
+                    i = semi; // ';' の位置まで進める
+                }
+                default -> throw new IllegalArgumentException("Unsupported descriptor char: " + c);
+            }
+            i++; // 現在の型記述を読み飛ばす
+            Type t = baseType;
+            if (arrayDim > 0) {
+                t = ArrayType.v(baseType, arrayDim);
+            }
+            types.add(t);
+        }
+        return types;
+    }
+}

--- a/src/main/java/org/example/LocTool.java
+++ b/src/main/java/org/example/LocTool.java
@@ -5,6 +5,7 @@ import soot.*;
 import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.jimple.toolkits.callgraph.Edge;
 import soot.options.Options;
+import org.example.DescriptorUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -140,7 +141,8 @@ public class LocTool {
         ExternalEntry[] entries = mapper.readValue(new File(jsonPath), ExternalEntry[].class);
         for (ExternalEntry entry : entries) {
             SootClass sc = Scene.v().getSootClass(entry.className());
-            SootMethod method = sc.getMethod(entry.method(), Collections.emptyList());
+            List<Type> paramTypes = DescriptorUtils.parseParameterTypes(entry.descriptor());
+            SootMethod method = sc.getMethod(entry.method(), paramTypes);
             functionEntryPoints.computeIfAbsent(entry.function(), k -> new HashSet<>())
                 .add(method);
         }


### PR DESCRIPTION
## Summary
- add `DescriptorUtils` to parse JVM method descriptors into parameter type lists
- update `collectExternalEntryPoints` to use parsed parameter types when obtaining methods

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_685040b882208321ac542ab636a802a9